### PR TITLE
Update develco.ts

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -222,15 +222,23 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SPLZB-131",
         vendor: "Develco",
         description: "Power plug",
+        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
         toZigbee: [tz.on_off],
         ota: true,
-        extend: [
-            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
-            develcoModernExtend.readGenBasicPrimaryVersions(),
-            develcoModernExtend.deviceTemperature(),
-            m.electricityMeter({acFrequency: true, fzMetering: develco.fz.metering, fzElectricalMeasurement: develco.fz.electrical_measurement}),
-            m.onOff(),
-        ],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(2);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "haElectricalMeasurement", "seMetering"]);
+            await reporting.onOff(endpoint);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.activePower(endpoint);
+            await reporting.rmsCurrent(endpoint);
+            await reporting.rmsVoltage(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint);
+            await reporting.acFrequency(endpoint);
+        },
         endpoint: (device) => {
             return {default: 2};
         },


### PR DESCRIPTION
Adopt SPLZB-141 converter for use with SPLZB-131.
Old Converter for SPLZB-131 did use unsupported "power_on_behaviour" leading to incomplete configuration attempts.